### PR TITLE
update setup.sh to shallow clone from mirror

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Clone the official postgres repository
-git clone http://git.postgresql.org/git/postgresql.git postgres/source
+# Shallow clone mirror of the official postgreSQL git repository
+ git clone https://github.com/postgres/postgres.git postgres/source --depth=1


### PR DESCRIPTION
To clone postgres with entire history is time-consuming, but the official git repository doesn't support shallow clone. To sovle this issue, we need to switch to the mirror in GitHub.
